### PR TITLE
Setup publishing to maven central

### DIFF
--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -1,0 +1,40 @@
+name: Maven Publish
+
+permissions: { }
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: ./.github/workflows/maven-verify.yaml
+
+  publish:
+    if: github.repository == 'schlunzis/zis-stomp'
+    needs: test
+    runs-on: ubuntu-latest
+    name: Publish to Maven Central
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish package
+        run: mvn -Dmaven.test.skip=true --batch-mode --update-snapshots -P publish deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven-verify.yaml
+++ b/.github/workflows/maven-verify.yaml
@@ -5,6 +5,7 @@ permissions: { }
 on:
   push:
   pull_request:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -6,16 +6,19 @@
     <parent>
         <groupId>org.schlunzis.zis.stomp</groupId>
         <artifactId>zis-stomp-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>annotation-processor</artifactId>
+
+    <name>Ze Impressive Schwifty STOMP Annotation Processor</name>
+    <description>Annotation processor to generate STOMP publisher.</description>
 
     <dependencies>
         <dependency>
             <groupId>org.schlunzis.zis.stomp</groupId>
             <artifactId>client</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,10 +6,13 @@
     <parent>
         <groupId>org.schlunzis.zis.stomp</groupId>
         <artifactId>zis-stomp-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>client</artifactId>
+
+    <name>Ze Impressive Schwifty STOMP Client</name>
+    <description>A STOMP client implementation using Jakarta WebSockets.</description>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,30 @@
 
     <groupId>org.schlunzis.zis.stomp</groupId>
     <artifactId>zis-stomp-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
+
+    <name>Ze Impressive Schwifty STOMP</name>
+    <description>A STOMP client and annotation processor.</description>
+    <licenses>
+        <license>
+            <name>GPL-3.0</name>
+            <url>https://www.gnu.org/licenses/gpl-3.0.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Tilman Holube</name>
+            <email>tilman@holube.de</email>
+            <organization>schlunzis</organization>
+            <organizationUrl>https://github.com/schlunzis</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/schlunzis/zis-stomp</url>
+        <connection>scm:git:git://github.com/schlunzis/zis-stomp.git</connection>
+        <developerConnection>scm:git:ssh://github.com/schlunzis/zis-stomp.git</developerConnection>
+    </scm>
 
     <modules>
         <module>client</module>
@@ -15,6 +37,7 @@
     </modules>
 
     <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -90,6 +113,75 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>publish</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.8</version>
+                        <configuration>
+                            <gpgArguments>
+                                <argument>--pinentry-mode</argument>
+                                <argument>loopback</argument>
+                            </gpgArguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <deploymentName>zis-stomp:${project.version}</deploymentName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Deployment

## Description

This PR adds configuration and a GitHub Action for deployment to maven central. The setup is designed to publish on push to main. If the version is a `-SNAPSHOT` version, it should only be available on maven central for 90 days. To release a real version, push a commit with a non-SNAPSHOT version. Auto-publishing is disabled. So if something goes wrong, the release is not really published on central and can be removed when needed.



