### PR TITLE
Allow subscribing with objects after client creation

### DIFF
--- a/client/src/it/subscriberObjects/invoker.properties
+++ b/client/src/it/subscriberObjects/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify

--- a/client/src/it/subscriberObjects/pom.xml
+++ b/client/src/it/subscriberObjects/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.schlunzis.zis.stomp.client.it</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jlink</packaging>
+
+    <properties>
+        <java.version>25</java.version>
+        <zis.stomp.version>@project.version@</zis.stomp.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.schlunzis.zis.stomp</groupId>
+            <artifactId>client</artifactId>
+            <version>${zis.stomp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-client</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-container-jdk-client</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.25.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jlink-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <launcher>
+                        main=org.schlunzis.zis.stomp.client.it/org.schlunzis.zis.stomp.client.it.Main
+                    </launcher>
+                    <noHeaderFiles>true</noHeaderFiles>
+                    <noManPages>true</noManPages>
+                    <stripDebug>true</stripDebug>
+                    <compress>zip-1</compress>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <id>run-jlink-main</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.build.directory}/maven-jlink/default/bin/main</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/client/src/it/subscriberObjects/src/main/java/module-info.java
+++ b/client/src/it/subscriberObjects/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module org.schlunzis.zis.stomp.client.it {
+    requires org.schlunzis.zis.stomp.client;
+    requires tools.jackson.databind;
+    requires jakarta.websocket.client;
+    requires org.glassfish.tyrus.client;
+    requires org.glassfish.tyrus.container.jdk.client;
+
+    exports org.schlunzis.zis.stomp.client.it;
+}

--- a/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Main.java
+++ b/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Main.java
@@ -1,0 +1,36 @@
+package org.schlunzis.zis.stomp.client.it;
+
+import org.schlunzis.zis.stomp.client.StompClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * This verifies that multiple subscribers can coexist and receive their respective messages.
+ * It sets up two subscribers with different expected message counts and ensures both receive their messages.
+ */
+public class Main {
+
+    static void main() throws URISyntaxException, InterruptedException {
+        StompClient stompClient = StompClient.builder()
+                .endpoint(new URI("ws://localhost:8080/ws"))
+                .build();
+        stompClient.connect();
+
+        Subscriber subscriber5 = new Subscriber(5);
+        stompClient.subscribe(subscriber5);
+        Subscriber subscriber1 = new Subscriber(1);
+        stompClient.subscribe(subscriber1);
+
+        subscriber1.awaitCountsReached();
+        stompClient.unsubscribe(subscriber1);
+
+        subscriber5.awaitCountsReached();
+        stompClient.unsubscribe(subscriber5);
+
+        Thread.sleep(2000);
+
+        stompClient.close();
+    }
+
+}

--- a/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Model.java
+++ b/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Model.java
@@ -1,0 +1,9 @@
+package org.schlunzis.zis.stomp.client.it;
+
+import java.util.UUID;
+
+public record Model(
+        UUID id,
+        String message
+) {
+}

--- a/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Subscriber.java
+++ b/client/src/it/subscriberObjects/src/main/java/org/schlunzis/zis/stomp/client/it/Subscriber.java
@@ -1,0 +1,46 @@
+package org.schlunzis.zis.stomp.client.it;
+
+import org.schlunzis.zis.stomp.client.StompSubscriber;
+import org.schlunzis.zis.stomp.client.Topic;
+
+import java.util.concurrent.CountDownLatch;
+
+@StompSubscriber(destinationPrefix = "/insight/scheduled/publisher/")
+public class Subscriber {
+
+    private final int expectedMessageCount;
+    private final CountDownLatch stringLatch;
+    private final CountDownLatch modelLatch;
+
+    public Subscriber(int expectedMessageCount) {
+        this.expectedMessageCount = expectedMessageCount;
+        this.stringLatch = new CountDownLatch(expectedMessageCount);
+        this.modelLatch = new CountDownLatch(expectedMessageCount);
+    }
+
+    public boolean awaitCountsReached() throws InterruptedException {
+        return stringLatch.await(expectedMessageCount + 10L, java.util.concurrent.TimeUnit.SECONDS) &&
+                modelLatch.await(expectedMessageCount + 10L, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    @Topic("string")
+    public void receiveString(String message) {
+        System.out.println("Received string message: " + message);
+        if (stringLatch.getCount() == 0) {
+            System.out.println("Received more string messages than expected!");
+            System.exit(2); // Fail the test if more messages are received than expected
+        }
+        stringLatch.countDown();
+    }
+
+    @Topic("model")
+    public void receiveModel(Model model) {
+        System.out.println("Received model message: " + model);
+        if (modelLatch.getCount() == 0) {
+            System.out.println("Received more model messages than expected!");
+            System.exit(2); // Fail the test if more messages are received than expected
+        }
+        modelLatch.countDown();
+    }
+
+}

--- a/client/src/main/java/org/schlunzis/zis/stomp/client/Stomp1dot2Client.java
+++ b/client/src/main/java/org/schlunzis/zis/stomp/client/Stomp1dot2Client.java
@@ -11,9 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,7 +28,8 @@ final class Stomp1dot2Client implements StompClient {
     private final URI endpoint;
     private final WebSocketClient websocketClient;
     private final SubscriptionManager subscriptionManager = new SubscriptionManager();
-    private final Collection<Subscription> subscriberSubscriptions;
+    private final SubscriberSubscriptionFactory subscriberSubscriptionFactory;
+    private final Map<Object, Set<Subscription>> subscriberSubscriptions = new ConcurrentHashMap<>();
     private final MessageConverter messageConverter;
     @Nullable
     private final OnErrorConsumer onErrorConsumer;
@@ -38,13 +38,12 @@ final class Stomp1dot2Client implements StompClient {
     private final TransferQueue<Frame> connectedFrames = new LinkedTransferQueue<>();
     private final Lock mutex = new ReentrantLock();
 
-    Stomp1dot2Client(URI endpoint, List<Object> subscribers, MessageConverter messageConverter, @Nullable OnErrorConsumer onErrorConsumer) {
+    Stomp1dot2Client(URI endpoint, MessageConverter messageConverter, @Nullable OnErrorConsumer onErrorConsumer) {
         this.endpoint = endpoint;
-        SubscriberSubscriptionFactory subscriberSubscriptionFactory = new SubscriberSubscriptionFactory(messageConverter);
-        this.subscriberSubscriptions = subscriberSubscriptionFactory.createAll(subscribers, this.subscriptionManager);
         this.websocketClient = new JakartaWebsocketClient(endpoint, this::handle);
         this.messageConverter = messageConverter;
         this.onErrorConsumer = onErrorConsumer;
+        this.subscriberSubscriptionFactory = new SubscriberSubscriptionFactory(messageConverter);
     }
 
     @Override
@@ -79,8 +78,6 @@ final class Stomp1dot2Client implements StompClient {
         } finally {
             mutex.unlock();
         }
-
-        subscriberSubscriptions.forEach(this::doSubscribe);
     }
 
     @Override
@@ -131,6 +128,31 @@ final class Stomp1dot2Client implements StompClient {
         return subscription;
     }
 
+    @Override
+    public void subscribe(Object subscriber) {
+        mutex.lock();
+        try {
+            ensureConnected();
+            if (subscriberSubscriptions.containsKey(subscriber)) {
+                throw new IllegalStateException("Subscriber is already subscribed: " + subscriber);
+            }
+
+            subscriberSubscriptions.computeIfAbsent(
+                    subscriber,
+                    _ -> {
+                        Set<Subscription> s = new HashSet<>();
+                        subscriberSubscriptionFactory.createAll(subscriptionManager, subscriber).forEach(subscription -> {
+                            doSubscribe(subscription);
+                            s.add(subscription);
+                        });
+                        return s;
+                    }
+            );
+        } finally {
+            mutex.unlock();
+        }
+    }
+
     private void doSubscribe(Subscription subscription) {
         Frame subscribeFrame = Frame.builder()
                 .command(Command.SUBSCRIBE)
@@ -151,6 +173,24 @@ final class Stomp1dot2Client implements StompClient {
         }
         doUnsubscribe(subscription);
         subscriptionManager.remove(subscription);
+    }
+
+    @Override
+    public void unsubscribe(Object subscriber) {
+        mutex.lock();
+        try {
+            ensureConnected();
+            Set<Subscription> subscriptions = subscriberSubscriptions.remove(subscriber);
+            if (subscriptions == null || subscriptions.isEmpty()) {
+                return;
+            }
+            for (Subscription subscription : subscriptions) {
+                doUnsubscribe(subscription);
+                subscriptionManager.remove(subscription);
+            }
+        } finally {
+            mutex.unlock();
+        }
     }
 
     private void doUnsubscribe(Subscription subscription) {
@@ -187,6 +227,7 @@ final class Stomp1dot2Client implements StompClient {
             connectionState.set(ConnectionState.DISCONNECTING);
             websocketClient.close();
             connectionState.set(ConnectionState.DISCONNECTED);
+            subscriberSubscriptions.clear();
         } finally {
             mutex.unlock();
         }

--- a/client/src/main/java/org/schlunzis/zis/stomp/client/StompClient.java
+++ b/client/src/main/java/org/schlunzis/zis/stomp/client/StompClient.java
@@ -100,6 +100,24 @@ public sealed interface StompClient
     <T> Subscription subscribe(String destination, Class<T> payloadType, Consumer<T> messageHandler);
 
     /**
+     * Subscribes all methods annotated with {@link Topic} in the given subscriber object.
+     * You can unsubscribe all created subscriptions by calling {@link #unsubscribe(Object)} with the same subscriber
+     * instance. To provide more configuration, annotate the class with {@link StompSubscriber}.
+     * <p>
+     * After calling this method, the subscriber's annotated methods will be invoked for incoming messages
+     * on their respective topics.
+     * If you call this method multiple times with the same subscriber instance,
+     * an {@link IllegalStateException} is thrown.
+     * <p>
+     * If the client is not connected, an {@link IllegalStateException} is thrown.
+     *
+     * @param subscriber the subscriber object containing methods annotated with {@link Topic}
+     * @throws IllegalStateException if the client is not connected
+     * @since 1.0.0
+     */
+    void subscribe(Object subscriber);
+
+    /**
      * Unsubscribes from the specified subscription.
      * <p>
      * After calling this method, no more messages will be received for the given subscription.
@@ -112,6 +130,21 @@ public sealed interface StompClient
      * @since 1.0.0
      */
     void unsubscribe(Subscription subscription);
+
+    /**
+     * Unsubscribes all subscriptions created from the given subscriber object.
+     * <p>
+     * After calling this method, no more messages will be received for any subscriptions created
+     * from the specified subscriber.
+     * If there are no subscriptions for the given subscriber, this method has no effect.
+     * <p>
+     * If the client is not connected, an {@link IllegalStateException} is thrown.
+     *
+     * @param subscriber the subscriber object whose subscriptions should be unsubscribed
+     * @throws IllegalStateException if the client is not connected
+     * @since 1.0.0
+     */
+    void unsubscribe(Object subscriber);
 
     /**
      * Closes the STOMP client and releases all associated resources.

--- a/client/src/main/java/org/schlunzis/zis/stomp/client/StompClientBuilder.java
+++ b/client/src/main/java/org/schlunzis/zis/stomp/client/StompClientBuilder.java
@@ -5,7 +5,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.*;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
 
 /**
  * Builder for {@link StompClient}.
@@ -19,7 +21,6 @@ public final class StompClientBuilder {
 
     @Nullable
     private URI endpoint;
-    private final List<Object> subscribers = new ArrayList<>();
     @Nullable
     private MessageConverter messageConverter;
     @Nullable
@@ -46,21 +47,6 @@ public final class StompClientBuilder {
      */
     public StompClientBuilder endpoint(URI endpoint) {
         this.endpoint = endpoint;
-        return this;
-    }
-
-    /**
-     * Adds a subscriber instance to the client. This instance must be annotated with
-     * {@link StompSubscriber} and its methods must be annotated with {@link Topic}.
-     * <p>
-     * This method may be called multiple times to add multiple subscribers.
-     *
-     * @param subscribers the subscriber instances
-     * @return the builder instance
-     * @since 1.0.0
-     */
-    public StompClientBuilder subscribers(List<Object> subscribers) {
-        this.subscribers.addAll(subscribers);
         return this;
     }
 
@@ -127,7 +113,6 @@ public final class StompClientBuilder {
 
         return new Stomp1dot2Client(
                 endpoint,
-                subscribers,
                 messageConverter,
                 onErrorConsumer
         );

--- a/client/src/main/java/org/schlunzis/zis/stomp/client/StompSubscriber.java
+++ b/client/src/main/java/org/schlunzis/zis/stomp/client/StompSubscriber.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.List;
 
 /**
  * Annotation to mark a class as a STOMP subscriber.
@@ -14,11 +13,12 @@ import java.util.List;
  * specifying a common prefix for all destinations handled by the subscriber. This prefix will be prepended
  * to the destination values defined in the {@code @Topic} annotations on the subscriber's methods.
  * <p>
- * To register a subscriber with a {@link StompClient}, pass an instance of the subscriber class
- * to the client builder using the {@link StompClientBuilder#subscribers(List)} method.
+ * To register a subscriber with a {@link StompClient}, pass an instance of the subscriber method
+ * to the client's {@link StompClient#subscribe(Object)} method.
+ * To unregister the subscriber and unsubscribe from all its topics, pass the same instance
+ * to the client's {@link StompClient#unsubscribe(Object)} method.
  *
  * @see Topic
- * @see StompClientBuilder#subscribers(List)
  * @see StompPublisher
  * @since 1.0.0
  */

--- a/client/src/main/java/org/schlunzis/zis/stomp/client/subscriptions/SubscriberSubscriptionFactory.java
+++ b/client/src/main/java/org/schlunzis/zis/stomp/client/subscriptions/SubscriberSubscriptionFactory.java
@@ -24,10 +24,8 @@ public final class SubscriberSubscriptionFactory {
         this.messageConverter = messageConverter;
     }
 
-    public List<Subscription> createAll(List<Object> subscribers, SubscriptionManager subscriptionManager) {
-        return subscribers.stream()
-                .flatMap(subscriber -> create(subscriber, subscriptionManager))
-                .toList();
+    public List<Subscription> createAll(SubscriptionManager subscriptionManager, Object subscriber) {
+        return create(subscriber, subscriptionManager).toList();
     }
 
     private Stream<Subscription> create(Object subscriber, SubscriptionManager subscriptionManager) {

--- a/client/src/test/java/org/schlunzis/zis/stomp/client/Stomp1dot2ClientTest.java
+++ b/client/src/test/java/org/schlunzis/zis/stomp/client/Stomp1dot2ClientTest.java
@@ -5,7 +5,6 @@ import org.schlunzis.zis.stomp.client.subscriptions.StompSubscription;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +16,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -44,7 +42,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://unreachable:9999/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -57,7 +54,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("http://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -70,7 +66,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -84,7 +79,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -97,7 +91,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -110,7 +103,6 @@ class Stomp1dot2ClientTest {
     void testCloseDouble() throws URISyntaxException, ConnectionException {
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -125,7 +117,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -138,7 +129,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 new StringMessageConverter(),
                 null
         );
@@ -153,7 +143,6 @@ class Stomp1dot2ClientTest {
         @SuppressWarnings("resource")
         Stomp1dot2Client client = new Stomp1dot2Client(
                 new URI("ws://localhost:8080/ws"),
-                List.of(),
                 messageConverter,
                 null
         );

--- a/test/mock-server/src/main/java/org/schlunzis/zis/stomp/mock_server/it/ScheduledPublisher.java
+++ b/test/mock-server/src/main/java/org/schlunzis/zis/stomp/mock_server/it/ScheduledPublisher.java
@@ -1,0 +1,23 @@
+package org.schlunzis.zis.stomp.mock_server.it;
+
+import lombok.RequiredArgsConstructor;
+import org.schlunzis.zis.stomp.mock_server.it.common.Model;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledPublisher {
+
+    private final SimpMessagingTemplate template;
+
+    @Scheduled(fixedRate = 1000)
+    public void send() {
+        this.template.convertAndSend("/insight/scheduled/publisher/string", "scheduled message");
+        this.template.convertAndSend("/insight/scheduled/publisher/model", new Model(UUID.randomUUID(), "scheduled model message"));
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Refactor
- Tests

## Description

- Removed registration of clients from builder
- Added subscribe and unsubscribe methods for subscriber objects

## Related Tickets & Documents

- Closes #23 


